### PR TITLE
changed environment because netlify doesn't host as prod

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  backendUrl: 'http://localhost:8080',
+  backendUrl: 'https://rapid-repair-backend-59fc436d8db1.herokuapp.com',
 };
 
 /*


### PR DESCRIPTION
Just changed the environment url, made it so that both the prod true and false use the same url. This is an attempt to fix an issue related to the authentication, refer to pull request on backend repo for more information,